### PR TITLE
Refactor to use global variables

### DIFF
--- a/cnphylogeny.c
+++ b/cnphylogeny.c
@@ -6,131 +6,48 @@
 #include <string.h>
 
 
-struct prob_matrix *prob_matrix_new(copy_num order, double *probs)
-{
-    int probs_len = order * order;
-
-    struct prob_matrix *matrix = malloc(
-        sizeof(struct prob_matrix) + probs_len * sizeof(double)
-    );
-    matrix->order = order;
-    for (int i = 0; i < probs_len; i++) matrix->probs[i] = log(probs[i]);
-
-    return matrix;
-}
-
-static double probs_lookup(struct prob_matrix *matrix, copy_num i, copy_num j)
-{
-    return matrix->probs[i * matrix->order + j];
-}
-
-
 struct gibbs_node {
-    size_t len;
-    copy_num state_count;
     copy_num *bins;
     copy_num *prev;
-    int *counts;
+    int **counts;
     struct gibbs_node *parent;
     struct gibbs_node *left;
     struct gibbs_node *right;
 };
 
+
 static struct gibbs_node *gibbs_node_new(
     struct cnp_node *src,
-    copy_num state_count,
     struct gibbs_node *parent
-)
+);
+static void gibbs_iteration(struct gibbs_node *node, bool count);
+static void gibbs_node_free(struct gibbs_node *node);
+
+static void cnp_get_mode(struct cnp_node *node, struct gibbs_node *src);
+
+
+double **prob_matrix_new(double *probs)
 {
-    if (!src) return NULL;
+    copy_num order = max_copy_num + 1;
+    double **matrix = malloc(
+        order * sizeof(double *) + order * order * sizeof(double)
+    );
 
-    struct gibbs_node *node = malloc(sizeof(struct gibbs_node));
-    node->len = src->len;
-    node->state_count = state_count;
-    node->bins = malloc(src->len);
-    memcpy(node->bins, src->bins, src->len);
-    node->prev = malloc(src->len);
-    memcpy(node->prev, src->bins, src->len);
-    node->counts = calloc(src->len * state_count, sizeof(int));
-    node->parent = parent;
-    node->left = gibbs_node_new(src->left, state_count, node);
-    node->right = gibbs_node_new(src->right, state_count, node);
-
-    return node;
-}
-
-static int *counts_lookup(struct gibbs_node *node, size_t bin, copy_num state)
-{
-    return node->counts + bin * node->state_count + state;
-}
-
-static void gibbs_iteration(
-    struct gibbs_node *node,
-    struct prob_matrix *neighbor_probs,
-    struct prob_matrix *mutation_probs,
-    bool count
-)
-{
-    if (!node || !node->left) return;
-
-    gibbs_iteration(node->left, neighbor_probs, mutation_probs, count);
-    gibbs_iteration(node->right, neighbor_probs, mutation_probs, count);
-
-    if (node->parent) {
-        for (int i = 0; i < node->len; i++) {
-            double max_prob = -INFINITY;
-            copy_num best = 0;
-            for (copy_num s = 0; s < node->state_count; s++) {
-                double prob = (
-                    probs_lookup(mutation_probs, node->parent->prev[i], s) +
-                    probs_lookup(mutation_probs, s, node->left->prev[i])
-                );
-                if (node->right)
-                    prob += probs_lookup(
-                        mutation_probs,
-                        s, node->right->prev[i]
-                    );
-                if (i > 0)
-                    prob += probs_lookup(neighbor_probs, node->prev[i - 1], s);
-                if (i < node->len - 1)
-                    prob += probs_lookup(neighbor_probs, s, node->prev[i + 1]);
-
-                if (prob > max_prob) {
-                    best = s;
-                    max_prob = prob;
-                }
-            }
-
-            node->bins[i] = best;
-            if (count) (*counts_lookup(node, i, best))++;
-        }
+    double *row = (double *) (matrix + order);
+    for (int i = 0; i < order; i++) {
+        matrix[i] = row;
+        row += order;
+        for (int j = 0; j < order; j++)
+            matrix[i][j] = log(probs[i * order + j]);
     }
 
-    memcpy(node->left->prev, node->left->bins, node->len);
-    if (node->right) memcpy(node->right->prev, node->right->bins, node->len);
-}
-
-static void gibbs_node_free(struct gibbs_node *node)
-{
-    if (!node) return;
-
-    free(node->bins);
-    free(node->prev);
-    free(node->counts);
-    gibbs_node_free(node->left);
-    gibbs_node_free(node->right);
-    free(node);
+    return matrix;
 }
 
 
-struct cnp_node *cnp_node_new(
-    size_t len,
-    struct cnp_node *left,
-    struct cnp_node *right
-)
+struct cnp_node *cnp_node_new(struct cnp_node *left, struct cnp_node *right)
 {
-    struct cnp_node *node = calloc(1, sizeof(struct cnp_node) + len);
-    node->len = len;
+    struct cnp_node *node = calloc(1, sizeof(struct cnp_node) + cnp_len);
     node->left = left;
     node->right = right;
 
@@ -146,6 +63,108 @@ void cnp_node_free(struct cnp_node *node)
     free(node);
 }
 
+
+void phylogeny_optimize(
+    struct cnp_node *root,
+    int burn_in,
+    int sample_rate,
+    int sample_count
+)
+{
+    struct gibbs_node *gibbs_root = gibbs_node_new(root, NULL);
+
+    for (int i = 0; i < burn_in; i++)
+        gibbs_iteration(gibbs_root, false);
+    for (int i = 0; i < sample_count; i++) {
+        gibbs_iteration(gibbs_root, true);
+        for (int j = 0; j < sample_rate - 1; j++)
+            gibbs_iteration(gibbs_root, false);
+    }
+
+    cnp_get_mode(root, gibbs_root);
+
+    gibbs_node_free(gibbs_root);
+}
+
+
+static struct gibbs_node *gibbs_node_new(
+    struct cnp_node *src,
+    struct gibbs_node *parent
+)
+{
+    if (!src) return NULL;
+
+    struct gibbs_node *node = malloc(sizeof(struct gibbs_node));
+    node->bins = malloc(cnp_len);
+    memcpy(node->bins, src->bins, cnp_len);
+    node->prev = malloc(cnp_len);
+    memcpy(node->prev, src->bins, cnp_len);
+    node->counts = calloc(
+        cnp_len * sizeof(int *) + cnp_len * (max_copy_num + 1), sizeof(int)
+    );
+    int *row = (int *) (node->counts + cnp_len);
+    for (int i = 0; i < cnp_len; i++) {
+        node->counts[i] = row;
+        row += max_copy_num + 1;
+    }
+    node->parent = parent;
+    node->left = gibbs_node_new(src->left, node);
+    node->right = gibbs_node_new(src->right, node);
+
+    return node;
+}
+
+static void gibbs_iteration(struct gibbs_node *node, bool count)
+{
+    if (!node || !node->left) return;
+
+    gibbs_iteration(node->left, count);
+    gibbs_iteration(node->right, count);
+
+    if (node->parent) {
+        for (int i = 0; i < cnp_len; i++) {
+            double max_prob = -INFINITY;
+            copy_num best = 0;
+            for (copy_num s = 0; s < max_copy_num + 1; s++) {
+                double prob = (
+                    mutation_probs[node->parent->prev[i]][s] +
+                    mutation_probs[s][node->left->prev[i]]
+                );
+                if (node->right)
+                    prob += mutation_probs[s][node->right->prev[i]];
+                if (i > 0)
+                    prob += neighbor_probs[node->prev[i - 1]][s];
+                if (i < cnp_len - 1)
+                    prob += neighbor_probs[s][node->prev[i + 1]];
+
+                if (prob > max_prob) {
+                    best = s;
+                    max_prob = prob;
+                }
+            }
+
+            node->bins[i] = best;
+            if (count) node->counts[i][best]++;
+        }
+    }
+
+    memcpy(node->left->prev, node->left->bins, cnp_len);
+    if (node->right) memcpy(node->right->prev, node->right->bins, cnp_len);
+}
+
+static void gibbs_node_free(struct gibbs_node *node)
+{
+    if (!node) return;
+
+    free(node->bins);
+    free(node->prev);
+    free(node->counts);
+    gibbs_node_free(node->left);
+    gibbs_node_free(node->right);
+    free(node);
+}
+
+
 static void cnp_get_mode(struct cnp_node *node, struct gibbs_node *src)
 {
     if (!node || !node->left) return;
@@ -155,11 +174,11 @@ static void cnp_get_mode(struct cnp_node *node, struct gibbs_node *src)
 
     if (!src->parent) return;
 
-    for (int i = 0; i < node->len; i++) {
+    for (int i = 0; i < cnp_len; i++) {
         int max_count = 0;
         copy_num mode;
-        for (int s = 0; s < src->state_count; s++) {
-            int count = *counts_lookup(src, i, s);
+        for (int s = 0; s < max_copy_num + 1; s++) {
+            int count = src->counts[i][s];
             if (count > max_count) {
                 mode = s;
                 max_count = count;
@@ -167,33 +186,4 @@ static void cnp_get_mode(struct cnp_node *node, struct gibbs_node *src)
         }
         node->bins[i] = mode;
     }
-}
-
-
-void phylogeny_optimize(
-    struct cnp_node *root,
-    struct prob_matrix *neighbor_probs,
-    struct prob_matrix *mutation_probs,
-    int burn_in,
-    int sample_rate,
-    int sample_count
-)
-{
-    struct gibbs_node *gibbs_root = gibbs_node_new(
-        root,
-        neighbor_probs->order,
-        NULL
-    );
-
-    for (int i = 0; i < burn_in; i++)
-        gibbs_iteration(gibbs_root, neighbor_probs, mutation_probs, false);
-    for (int i = 0; i < sample_count; i++) {
-        gibbs_iteration(gibbs_root, neighbor_probs, mutation_probs, true);
-        for (int j = 0; j < sample_rate - 1; j++)
-            gibbs_iteration(gibbs_root, neighbor_probs, mutation_probs, false);
-    }
-
-    cnp_get_mode(root, gibbs_root);
-
-    gibbs_node_free(gibbs_root);
 }

--- a/cnphylogeny.h
+++ b/cnphylogeny.h
@@ -27,16 +27,14 @@ struct cnp_node {
 /**
  * @brief The length of a CNP
  *
- * This variable must be defined before calling `cnp_node_new()` or
- * `phylogeny_optimize()`.
+ * This variable must be defined.
  */
 extern size_t cnp_len;
 
 /**
  * @brief The maximum possible copy number
  *
- * This variable must be defined before calling `prob_matrix_new()` or
- * `phylogeny_optimize()`.
+ * This variable must be defined.
  */
 extern copy_num max_copy_num;
 
@@ -45,8 +43,9 @@ extern copy_num max_copy_num;
  *        configuration of two neighboring bins
  *
  * `neighbor_probs[i][j]` gives the log probability of observing a bin with copy
- * number `i` followed by a bin with copy number `j` (in the same CNP). This
- * variable must be defined before calling `phylogeny_optimize()`.
+ * number `i` followed by a bin with copy number `j` (in the same CNP).
+ *
+ * This variable must be defined.
  */
 extern double **neighbor_probs;
 
@@ -56,8 +55,9 @@ extern double **neighbor_probs;
  *
  * `neighbor_probs[i][j]` gives the log probability of observing a bin with copy
  * number `i` in a parent CNP and a bin with copy number `j` in the
- * corresponding position of its child. This variable must be defined before
- * calling `phylogeny_optimize()`.
+ * corresponding position of its child.
+ *
+ * This variable must be defined.
  */
 extern double **mutation_probs;
 

--- a/cnphylogeny.h
+++ b/cnphylogeny.h
@@ -35,7 +35,7 @@ extern size_t cnp_len;
 /**
  * @brief The maximum possible copy number
  *
- * This variable must be defined before calling `cnp_node_new()` or
+ * This variable must be defined before calling `prob_matrix_new()` or
  * `phylogeny_optimize()`.
  */
 extern copy_num max_copy_num;
@@ -65,8 +65,9 @@ extern double **mutation_probs;
 /**
  * @brief Allocate and assign a probability matrix
  *
- * The new matrix will have order `max_copy_num + 1` and will store a copy of
- * `probs`, not a reference to it.
+ * The new matrix will have order `max_copy_num + 1`. Note that the
+ * probabilities will be stored as natural log probabilities; be careful when
+ * modifying an existing probability matrix.
  *
  * @param probs A pointer to the elements of the matrix, flattened into an array
  *              (often, a compound literal)

--- a/tests/cnp_node_new_free.c
+++ b/tests/cnp_node_new_free.c
@@ -2,14 +2,19 @@
 
 #include <assert.h>
 
+
+size_t cnp_len = 1000;
+copy_num max_copy_num;
+double **neighbor_probs;
+double **mutation_probs;
+
+
 int main()
 {
     struct cnp_node *node = cnp_node_new(
-        1000,
         cnp_node_new(
-            1000,
-            cnp_node_new(1000, NULL, NULL),
-            cnp_node_new(1000, NULL, NULL)
+            cnp_node_new(NULL, NULL),
+            cnp_node_new(NULL, NULL)
         ),
         NULL
     );

--- a/tests/phylogeny_optimize.c
+++ b/tests/phylogeny_optimize.c
@@ -3,15 +3,17 @@
 #include <assert.h>
 #include <string.h>
 
-static struct prob_matrix *neighbor_probs;
-static struct prob_matrix *mutation_probs;
+size_t cnp_len = 5;
+copy_num max_copy_num = 2;
+double **neighbor_probs;
+double **mutation_probs;
 
-struct cnp_node *root;
-struct cnp_node *interior1;
-struct cnp_node *leaf1;
-struct cnp_node *interior2;
-struct cnp_node *leaf2;
-struct cnp_node *leaf3;
+static struct cnp_node *root;
+static struct cnp_node *interior1;
+static struct cnp_node *leaf1;
+static struct cnp_node *interior2;
+static struct cnp_node *leaf2;
+static struct cnp_node *leaf3;
 
 
 void test_iteration()
@@ -23,17 +25,17 @@ void test_iteration()
     memcpy(leaf2->bins, (copy_num []) { 2, 0, 2, 2, 2 }, 5);
     memcpy(leaf3->bins, (copy_num []) { 1, 1, 1, 2, 2 }, 5);
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 0, 1, 1);
+    phylogeny_optimize(root, 0, 1, 1);
 
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 1 }, 5));
     assert(!memcmp(interior2->bins, (copy_num []) { 0, 0, 0, 0, 0 }, 5));
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 0, 1, 1);
+    phylogeny_optimize(root, 0, 1, 1);
 
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 1 }, 5));
     assert(!memcmp(interior2->bins, (copy_num []) { 2, 1, 1, 2, 2 }, 5));
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 0, 1, 1);
+    phylogeny_optimize(root, 0, 1, 1);
 
     assert(!memcmp(root->bins, (copy_num []) { 2, 2, 2, 2, 2 }, 5));
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 2 }, 5));
@@ -52,7 +54,7 @@ void test_burn_in()
     memcpy(leaf2->bins, (copy_num []) { 2, 0, 2, 2, 2 }, 5);
     memcpy(leaf3->bins, (copy_num []) { 1, 1, 1, 2, 2 }, 5);
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 2, 1, 1);
+    phylogeny_optimize(root, 2, 1, 1);
 
     assert(!memcmp(root->bins, (copy_num []) { 2, 2, 2, 2, 2 }, 5));
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 2 }, 5));
@@ -70,7 +72,7 @@ void test_mode() {
     memcpy(leaf2->bins, (copy_num []) { 2, 0, 2, 2, 2 }, 5);
     memcpy(leaf3->bins, (copy_num []) { 1, 1, 1, 2, 2 }, 5);
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 0, 1, 3);
+    phylogeny_optimize(root, 0, 1, 3);
 
     assert(!memcmp(root->bins, (copy_num []) { 2, 2, 2, 2, 2 }, 5));
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 1 }, 5));
@@ -88,7 +90,7 @@ void test_sample_rate() {
     memcpy(leaf2->bins, (copy_num []) { 2, 0, 2, 2, 2 }, 5);
     memcpy(leaf3->bins, (copy_num []) { 1, 1, 1, 2, 2 }, 5);
 
-    phylogeny_optimize(root, neighbor_probs, mutation_probs, 0, 2, 2);
+    phylogeny_optimize(root, 0, 2, 2);
 
     assert(!memcmp(root->bins, (copy_num []) { 2, 2, 2, 2, 2 }, 5));
     assert(!memcmp(interior1->bins, (copy_num []) { 2, 2, 1, 1, 1 }, 5));
@@ -101,26 +103,23 @@ void test_sample_rate() {
 
 int main()
 {
-    neighbor_probs = prob_matrix_new(3, (double []) {
+    neighbor_probs = prob_matrix_new((double []) {
         0.9, 0.05, 0.05,
         0.05, 0.9, 0.05,
         0.05, 0.05, 0.9,
     });
-    mutation_probs = prob_matrix_new(3, (double []) {
+    mutation_probs = prob_matrix_new((double []) {
         1, 0, 0,
         0.005, 0.99, 0.005,
         0.005, 0.005, 0.99,
     });
 
     root = cnp_node_new(
-        5,
         cnp_node_new(
-            5,
-            cnp_node_new(5, NULL, NULL),
+            cnp_node_new(NULL, NULL),
             cnp_node_new(
-                5,
-                cnp_node_new(5, NULL, NULL),
-                cnp_node_new(5, NULL, NULL)
+                cnp_node_new(NULL, NULL),
+                cnp_node_new(NULL, NULL)
             )
         ),
         NULL

--- a/tests/phylogeny_optimize.c
+++ b/tests/phylogeny_optimize.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <string.h>
 
+
 size_t cnp_len = 5;
 copy_num max_copy_num = 2;
 double **neighbor_probs;

--- a/tests/prob_matrix_new.c
+++ b/tests/prob_matrix_new.c
@@ -3,17 +3,24 @@
 #include <assert.h>
 #include <math.h>
 
+
+size_t cnp_len;
+copy_num max_copy_num = 1;
+double **neighbor_probs;
+double **mutation_probs;
+
+
 int main()
 {
-    struct prob_matrix *probs = prob_matrix_new(2, (double []) {
+    double **probs = prob_matrix_new((double []) {
         1, 0,
         0, 1,
     });
 
-    assert(probs->probs[0] == 0);
-    assert(probs->probs[1] == -INFINITY);
-    assert(probs->probs[2] == -INFINITY);
-    assert(probs->probs[3] == 0);
+    assert(probs[0][0] == 0);
+    assert(probs[0][1] == -INFINITY);
+    assert(probs[1][0] == -INFINITY);
+    assert(probs[1][1] == 0);
 
     free(probs);
 


### PR DESCRIPTION
This pull request adds the global variables `cnp_len`, `max_copy_number`, `neighbor_probs`, and `mutation_probs`, which are used to define parameters. This eliminates the need to repeatedly pass these parameters as function arguments. Also, `struct prob_matrix` is no more.